### PR TITLE
Better describe lts-candidate issue update process

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/1-lts-release-checklist.md
@@ -38,7 +38,7 @@ This role should rotate between LTS releases
 
 - [ ] Backporting announcement email - [generate-backporting-announcement script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/generate-backporting-announcement)
 
-- [ ] Update jira labels with the selected issues, e.g. `2.277.2-fixed`, `2.277.2-rejected`, and remove `lts-candidate`
+- [ ] Update jira labels for [lts-candidate issues](https://issues.jenkins.io/issues/?filter=12146), either add `2.277.2-fixed` and remove `lts-candidate` or add `2.277.2-rejected`, and retain `lts-candidate`
 
 - [ ] Backport changes, create a local branch in jenkinsci/jenkins, run the [list-issue-commits script](https://github.com/jenkins-infra/backend-commit-history-parser/blob/master/bin/list-issue-commits) to locate commits via jira ID, some manual work is required to locate them if the issue ID wasn't present at merge time, backport with `git cherry-pick -x $commit`
 


### PR DESCRIPTION
## Update all lts-candidate issues at LTS release

Issues that are tagged `lts-candidate` should be visited to be either marked `2.xxx.y-fixed` or be marked `2.xxx.y-rejected`.  When rejected for a specific LTS, they retain the `lts-candidate` label so they will be considered for the next LTS.  When included in an LTS, the `lts-candidate` label should be removed.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue